### PR TITLE
Fix match error on file extension check

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = function (movieString) {
 
-  var baseName = movieString.replace(/\.(avi|mkv|mpeg|mpg|mov|mp4|m4v)$/i, '');
+  var baseName = movieString.trim().replace(/\.(avi|mkv|mpeg|mpg|mov|mp4|m4v)$/i, '');
   var movie = baseName.match(/(.*?)(directors(.?)cut|480p|720p|1080p|dvdrip|xvid|cd[0-9]|bluray|dvdscr|brrip|divx|S[0-9]{1,3}E[0-9]{1,3}|Season[\s,0-9]{1,4}|[\{\(\[]?[0-9]{4}).*/i);
 
   if (movie && movie[1]) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = function (movieString) {
 
-  var baseName = movieString.replace(/\.(avi|mkv|mpeg|mpg|mov|mp4|m4v)/i, '');
+  var baseName = movieString.replace(/\.(avi|mkv|mpeg|mpg|mov|mp4|m4v)$/i, '');
   var movie = baseName.match(/(.*?)(directors(.?)cut|480p|720p|1080p|dvdrip|xvid|cd[0-9]|bluray|dvdscr|brrip|divx|S[0-9]{1,3}E[0-9]{1,3}|Season[\s,0-9]{1,4}|[\{\(\[]?[0-9]{4}).*/i);
 
   if (movie && movie[1]) {


### PR DESCRIPTION
With the current code, if the file name contains any of the possible extensions with a dot before it, it will be matched and removed.
An example of this would be the emoji movie, if its file is, for example, The.Emoji.Movie.mp4, both the .mp4 and .Mov in movie will be matched and removed making the final match as Emojiie. Fixed by adding the check to make sure the file extension is actually at the end of the filename, I just added an end check via $.